### PR TITLE
Revert "binary: Generate dummy rule for relocated protobuf headers"

### DIFF
--- a/core/binary.mk
+++ b/core/binary.mk
@@ -542,9 +542,10 @@ define copy-proto-files
 $(if $(PRIVATE_PROTOC_OUTPUT), \
    $(if $(call streq,$(PRIVATE_PROTOC_INPUT),$(PRIVATE_PROTOC_OUTPUT)),, \
    $(eval proto_generated_path := $(dir $(subst $(PRIVATE_PROTOC_INPUT),$(PRIVATE_PROTOC_OUTPUT),$@)))
+   $(eval proto_target_files := $(patsubst %.pb$(PRIVATE_PROTOC_SUFFIX), %.pb.*, $@))
    @mkdir -p $(dir $(proto_generated_path))
-   @echo "Protobuf relocation: $@ => $(proto_generated_path)"
-   @cp -f $@ $(proto_generated_path) ),)
+   @echo "Protobuf relocation: $(proto_target_files) => $(proto_generated_path)"
+   @cp -f $(proto_target_files) $(proto_generated_path) ),)
 endef
 
 
@@ -554,28 +555,15 @@ $(proto_generated_sources): PRIVATE_PROTO_INCLUDES := $(TOP)
 $(proto_generated_sources): PRIVATE_PROTOC_FLAGS := $(LOCAL_PROTOC_FLAGS) $(my_protoc_flags)
 $(proto_generated_sources): PRIVATE_PROTOC_OUTPUT := $(LOCAL_PROTOC_OUTPUT)
 $(proto_generated_sources): PRIVATE_PROTOC_INPUT := $(LOCAL_PATH)
+$(proto_generated_sources): PRIVATE_PROTOC_SUFFIX := $(my_proto_source_suffix)
 $(proto_generated_sources): $(proto_generated_sources_dir)/%.pb$(my_proto_source_suffix): %.proto $(PROTOC)
 	$(transform-proto-to-cc)
 	$(copy-proto-files)
 
 # This is just a dummy rule to make sure gmake doesn't skip updating the dependents.
-$(proto_generated_headers): PRIVATE_PROTOC_OUTPUT := $(LOCAL_PROTOC_OUTPUT)
-$(proto_generated_headers): PRIVATE_PROTOC_INPUT := $(LOCAL_PATH)
 $(proto_generated_headers): $(proto_generated_sources_dir)/%.pb.h: $(proto_generated_sources_dir)/%.pb$(my_proto_source_suffix)
 	@echo "Updated header file $@."
 	$(hide) touch $@
-	$(copy-proto-files)
-
-$(if $(LOCAL_PROTOC_OUTPUT), \
-$(if $(call streq,$(LOCAL_PROTOC_OUTPUT),$(LOCAL_PATH)),, \
-  $(eval proto_relocated_headers := $(subst $(LOCAL_PATH),$(LOCAL_PROTOC_OUTPUT),$(proto_generated_headers))) \
- ), )
-
-ifdef proto_relocated_headers
-$(proto_relocated_headers): $(proto_generated_headers)
-	echo "Refreshed header file $@."
-	$(hide) touch $@
-endif
 
 $(my_prefix)_$(LOCAL_MODULE_CLASS)_$(LOCAL_MODULE)_proto_defined := true
 endif  # transform-proto-to-cc rule included only once


### PR DESCRIPTION
This reverts commit ba297413c51feab9fa43be5af56e12b79891f5fb.
The dummy rule creates an empty file. Instead of relying on header
dependency resolution, copy all protobuf output when the source
is generated in replacement of separate source/header steps.

Change-Id: I358459be7c812afea5be56e14dc74ea11abb3502